### PR TITLE
Run the rake tasks in a subprocess:

### DIFF
--- a/lib/easy_compile/compilation_tasks.rb
+++ b/lib/easy_compile/compilation_tasks.rb
@@ -9,13 +9,13 @@ module EasyCompile
   class CompilationTasks
     include Gem::GemspecHelpers
 
-    attr_reader :gemspec, :native
+    attr_reader :gemspec, :native, :create_packaging_task
     attr_accessor :binary_name
 
-    def initialize(gemspec, create_packaging_task)
+    def initialize(create_packaging_task = false, gemspec = nil)
       @gemspec  = Bundler.load_gemspec(gemspec || find_gemspec)
 
-      setup_packaging if create_packaging_task
+      @create_packaging_task = create_packaging_task
     end
 
     def setup
@@ -24,6 +24,8 @@ module EasyCompile
           define_task(path)
         end
       end
+
+      setup_packaging if create_packaging_task
     end
 
     def ruby_cc_version

--- a/lib/easy_compile/tasks/wrapper.rake
+++ b/lib/easy_compile/tasks/wrapper.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "../compilation_tasks"
+
+task = EasyCompile::CompilationTasks.new(!Rake::Task.task_defined?(:package))
+task.setup


### PR DESCRIPTION
- ### Problem

  It's quite a common isue when building a tool in Ruby and that tool isn't supposed to be added as a dependency of an application/library. Basically, this tool depends on thor, rake-compiler and rake as a transitive dependencies. When those gets required, the target application may have the same dependencies but pinned to a different versions.

  As soon as this tool try to execute code on the target app, it's likely that we'll stumble upon a `require bundler/setup` which activates the specs of the target application but first ensure there is no conflicts.

  ### Solution

  What most tool does is to vendor the dependencies. In this case, vendoring the dependencies may be overkilled and I instead decided to use rake task features:

  1. When the `easy_compile` executable is called, we add the `rake-compiler` path to the $LOAD_PATH.
  2. We then execute `bundle exec rake ...` and pass the `-R` flag, which tells Rake to load all rakefiles in that directory. Our own rake task that gets imported by Rake will setup the tasks for the subprocess.
  3. Our own task depends on `rake/extensiontask` which may not be present in the target application dependencies, the require calls succeeds thanks to the $LOAD_PATH we set in 1.