### PR TITLE
Create the GitHub workflow template:

### DIFF
--- a/lib/easy_compile.rb
+++ b/lib/easy_compile.rb
@@ -5,4 +5,5 @@ require_relative "easy_compile/version"
 module EasyCompile
   autoload :CLI,              "easy_compile/cli"
   autoload :CompilationTasks, "easy_compile/compilation_tasks"
+  autoload :RubySeries,       "easy_compile/ruby_series"
 end

--- a/lib/easy_compile/cli.rb
+++ b/lib/easy_compile/cli.rb
@@ -50,10 +50,13 @@ module EasyCompile
     end
 
     desc "ci_template", "Generate CI template files"
-    method_option "rubies", type: :array, required: true, desc: "The Ruby version you want to test your gem on."
-    method_option "os", type: :array, required: true, desc: "The operating systems you want to test your gem on."
     def ci_template
-      directory(".github")
+      os = ["macos-latest", "macos-15-intel", "ubuntu-latest", "windows-latest"]
+      ruby_requirements = compilation_task.gemspec.required_ruby_version
+      latest_supported_ruby_version = RubySeries.latest_version_for_requirements(ruby_requirements)
+      ruby_versions_for_testing = RubySeries.versions_to_test_agaist(ruby_requirements).map(&:to_s)
+
+      directory(".github", context: instance_eval("binding"))
     end
 
     desc "release", "Release the gem with precompiled binaries"

--- a/lib/easy_compile/compilation_tasks.rb
+++ b/lib/easy_compile/compilation_tasks.rb
@@ -27,10 +27,7 @@ module EasyCompile
 
     def ruby_cc_version
       required_ruby_version = @gemspec.required_ruby_version
-
-      selected_rubies = cross_rubies.select do |ruby_version|
-        required_ruby_version.satisfied_by?(ruby_version)
-      end
+      selected_rubies = RubySeries.versions_to_compile_against(required_ruby_version)
 
       selected_rubies.map(&:to_s).join(":")
     end
@@ -109,17 +106,6 @@ module EasyCompile
       return platform unless darwin?
 
       RUBY_PLATFORM.sub(/(.*-darwin)\d+/, '\1')
-    end
-
-    def cross_rubies
-      versions = [
-        "3.4.6",
-        "3.3.9",
-        "3.2.9",
-      ]
-     versions.push("3.1.7", "3.0.7") unless Gem.win_platform? # GCC 15 incompatibility on Ruby 3.1 and 3.0 for windows.
-
-     versions.map { |version| Gem::Version.new(version) }
     end
 
     def find_gemspec(glob = "*.gemspec")

--- a/lib/easy_compile/ruby_series.rb
+++ b/lib/easy_compile/ruby_series.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module EasyCompile
+  module RubySeries
+    extend self
+
+    def latest_version_for_requirements(requirements)
+      latest_rubies.find do |ruby_version|
+        requirements.satisfied_by?(ruby_version)
+      end
+    end
+    alias_method :runtime_version_for_compilation, :latest_version_for_requirements
+
+    def versions_to_compile_against(requirements)
+      cross_rubies.select do |ruby_version|
+        requirements.satisfied_by?(ruby_version)
+      end
+    end
+
+    def versions_to_test_agaist(requirements)
+      latest_rubies.select do |ruby_version|
+        requirements.satisfied_by?(ruby_version)
+      end
+    end
+
+    def cross_rubies
+      [
+        Gem::Version.new("3.4.6"),
+        Gem::Version.new("3.3.8"),
+        Gem::Version.new("3.2.8"),
+        Gem::Version.new("3.1.6"),
+        Gem::Version.new("3.0.6"),
+      ]
+    end
+
+    def latest_rubies
+      [
+        Gem::Version.new("3.4.7"),
+        Gem::Version.new("3.3.9"),
+        Gem::Version.new("3.2.9"),
+        Gem::Version.new("3.1.7"),
+        Gem::Version.new("3.0.7"),
+      ]
+    end
+  end
+end

--- a/lib/easy_compile/templates/.github/workflows/easy-compile.yaml.tt
+++ b/lib/easy_compile/templates/.github/workflows/easy-compile.yaml.tt
@@ -1,19 +1,84 @@
-name: Compile and test a dummy gem
-on: [push]
+name: "Package gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
 jobs:
-  easy-compile:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        version: <%= options[:rubies] %>
-        os: <%= options[:os] %>
+        os: <%= os %>
     runs-on: "${{ matrix.os }}"
     steps:
-      - name: "Run easy compile"
+      - name: "Checkout code"
         uses: "actions/checkout@v5"
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "${{ matrix.version }}"
+          ruby-version: "<%= latest_supported_ruby_version %>"
           bundler-cache: true
       - name: "Run easy compile"
-        uses: "shopify-playground/edouard-playground/easy_compile/.github/actions/easy_compile@main"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@easy-compile"
+        with:
+          step: "compile"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: <%= os %>
+        rubies: <%= ruby_versions_for_testing %>
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@easy-compile"
+        with:
+          step: "test_${{ matrix.type }}"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: <%= os %>
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "<%= latest_supported_ruby_version %>"
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@easy-compile"
+        with:
+          step: "install"
+  release:
+    permissions:
+      id-token: write
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+          bundler-cache: true
+      - name: "Run easy compile"
+        uses: "shopify-playground/edouard-playground/.github/actions/easy_publish@easy-compile"


### PR DESCRIPTION
Create the GitHub workflow template:

- The goal is to let user generate a GitHub workflow template that is configured to work with the easy compile tool.

  For now every configuration that are specific to a gem are infered from the gemspec. It may be good in the future to let users customize some values such as the platform to run against.