### PR TITLE
Use the minimum supported version for compiling:

### DIFF
--- a/.github/actions/easy_compile/dist/index.js
+++ b/.github/actions/easy_compile/dist/index.js
@@ -28231,7 +28231,7 @@ function setupRakeCompilerConfig() {
   let rubiesRbConfig = fs.globSync(`${rubiesPath()}/*/*/lib/ruby/*/*/rbconfig.rb`)
   let currentRubyVersion = cp.execSync('ruby -v', { encoding: 'utf-8' }).match(/^ruby (\d\.\d\.\d)/)[1]
   let rbConfigPath = path.join(os.homedir(), ".rake-compiler", "config.yml")
-  let rubyPlatform = withoutDarwinVersioning(cp.execSync('ruby -e "print RUBY_PLATFORM"', { encoding: 'utf-8' }))
+  let rubyPlatform = cp.execSync('easy_compile print_normalized_platform', { encoding: 'utf-8' })
 
   fs.mkdirSync(`${os.homedir()}/.rake-compiler`)
 
@@ -28247,14 +28247,6 @@ function setupRakeCompilerConfig() {
 
 function rubiesPath() {
   return path.join(process.env['RUNNER_TEMP'], 'rubies');
-}
-
-function withoutDarwinVersioning(platform) {
-  if (!isDarwin()) {
-    return platform
-  }
-
-  return platform.replace(/(.*-darwin)\d+/, '$1')
 }
 
 function getRbConfigName(rubyPlatform, rubyVersion) {

--- a/.github/actions/easy_compile/src/index.js
+++ b/.github/actions/easy_compile/src/index.js
@@ -30,7 +30,7 @@ function setupRakeCompilerConfig() {
   let rubiesRbConfig = fs.globSync(`${rubiesPath()}/*/*/lib/ruby/*/*/rbconfig.rb`)
   let currentRubyVersion = cp.execSync('ruby -v', { encoding: 'utf-8' }).match(/^ruby (\d\.\d\.\d)/)[1]
   let rbConfigPath = path.join(os.homedir(), ".rake-compiler", "config.yml")
-  let rubyPlatform = withoutDarwinVersioning(cp.execSync('ruby -e "print RUBY_PLATFORM"', { encoding: 'utf-8' }))
+  let rubyPlatform = cp.execSync('easy_compile print_normalized_platform', { encoding: 'utf-8' })
 
   fs.mkdirSync(`${os.homedir()}/.rake-compiler`)
 
@@ -46,14 +46,6 @@ function setupRakeCompilerConfig() {
 
 function rubiesPath() {
   return path.join(process.env['RUNNER_TEMP'], 'rubies');
-}
-
-function withoutDarwinVersioning(platform) {
-  if (!isDarwin()) {
-    return platform
-  }
-
-  return platform.replace(/(.*-darwin)\d+/, '$1')
 }
 
 function getRbConfigName(rubyPlatform, rubyVersion) {

--- a/.github/workflows/gem-compile.yml
+++ b/.github/workflows/gem-compile.yml
@@ -7,37 +7,41 @@ on:
         required: false
         type: boolean
         default: false
+
 jobs:
   compile:
     timeout-minutes: 20
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
+      - name: "Install gperf"
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install gperf
       - name: "Checkout code"
         uses: "actions/checkout@v5"
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.4.7"
+          ruby-version: "3.0.7"
           bundler-cache: true
           working-directory: "test/fixtures/date"
       - name: "Run easy compile"
         uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
         with:
           step: "compile"
+          token: ${{ secrets.GITHUB_TOKEN }} # TODO Remove this before publishing the gem
           working-directory: "test/fixtures/date"
-          token: ${{ secrets.GITHUB_TOKEN  }}
   test:
     timeout-minutes: 20
     name: "Run the test suite"
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
-        rubies: ["3.4.7", "3.3.9"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        rubies: ["3.4.7", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
     steps:
@@ -53,15 +57,15 @@ jobs:
         uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
         with:
           step: "test_${{ matrix.type }}"
+          token: ${{ secrets.GITHUB_TOKEN }} # TODO Remove this before publishing the gem
           working-directory: "test/fixtures/date"
-          token: ${{ secrets.GITHUB_TOKEN  }}
   install:
     timeout-minutes: 5
     name: "Verify the gem can be installed"
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Setup Ruby"
@@ -71,8 +75,8 @@ jobs:
       - name: "Run easy compile"
         uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
         with:
+          token: ${{ secrets.GITHUB_TOKEN }} # TODO Remove this before publishing the gem
           step: "install"
-          token: ${{ secrets.GITHUB_TOKEN  }}
   release:
     permissions:
       id-token: write

--- a/lib/easy_compile/cli.rb
+++ b/lib/easy_compile/cli.rb
@@ -88,6 +88,7 @@ module EasyCompile
       os = ["macos-latest", "ubuntu-latest"] # Just this for now because the CI takes too long otherwise.
       ruby_requirements = compilation_task.gemspec.required_ruby_version
       latest_supported_ruby_version = RubySeries.latest_version_for_requirements(ruby_requirements)
+      runtime_version_for_compilation = RubySeries.runtime_version_for_compilation(ruby_requirements)
       ruby_versions_for_testing = RubySeries.versions_to_test_agaist(ruby_requirements).map(&:to_s)
 
       directory(".github", context: instance_eval("binding"))
@@ -108,6 +109,11 @@ module EasyCompile
     method_option "gemspec", type: "string", required: false, desc: "The gemspec to use. If the option is not passed, a gemspec file from the current working directory will be used."
     def print_ruby_cc_version
       print compilation_task.ruby_cc_version
+    end
+
+    desc "normalized_platform", "The platform name for compilation purposes", hide: true
+    def print_normalized_platform
+      print compilation_task.normalized_platform
     end
 
     private

--- a/lib/easy_compile/ruby_series.rb
+++ b/lib/easy_compile/ruby_series.rb
@@ -9,7 +9,15 @@ module EasyCompile
         requirements.satisfied_by?(ruby_version)
       end
     end
-    alias_method :runtime_version_for_compilation, :latest_version_for_requirements
+
+    # Get the minimum Ruby version to run the compilation. Getting the minimum Ruby
+    # version allows ruby/setup-ruby to download the right MSYS2 toolchain and get the
+    # right GCC version. GCC 15.1 is incompatible with Ruby 3.0 and 3.1.
+    def runtime_version_for_compilation(requirements)
+      latest_rubies.reverse.find do |ruby_version|
+        requirements.satisfied_by?(ruby_version)
+      end
+    end
 
     def versions_to_compile_against(requirements)
       cross_rubies.select do |ruby_version|

--- a/lib/easy_compile/tasks/wrapper.rake
+++ b/lib/easy_compile/tasks/wrapper.rake
@@ -7,7 +7,8 @@ task.setup
 
 task "copy:stage:lib" do
   version = RUBY_VERSION.match(/(\d\.\d)/)[1]
-  path = "#{task.extension_task.lib_dir}/#{version}"
+  dest = File.join(task.extension_task.lib_dir, version)
+  src = File.join("tmp", task.extension_task.cross_platform, "stage", dest)
 
-  cp_r("tmp/#{task.extension_task.cross_platform}/stage/#{path}", path, remove_destination: true)
+  cp_r(src, dest, remove_destination: true)
 end

--- a/lib/easy_compile/templates/.github/workflows/easy-compile.yaml.tt
+++ b/lib/easy_compile/templates/.github/workflows/easy-compile.yaml.tt
@@ -21,7 +21,7 @@ jobs:
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "<%= latest_supported_ruby_version %>"
+          ruby-version: "<%= runtime_version_for_compilation %>"
           bundler-cache: true
           <%- if options['working-directory'] -%>
           working-directory: "<%= options['working-directory'] %>"


### PR DESCRIPTION
- When we use the maximum supported versions, ruby/setup-ruby installs the default MSYS2 toolchain on windows which includes GCC 15.1. The problem is that GCC 15.1 is incompatible with Ruby 3.1 and 3.0, so when we end up compiling the fat gem we get compilation errors. By using the minimum supported versions (e.g. 3.1), we ensure that the correct GCC version 14.0 is going to be used.

  Now, because we use the first supported versions, running `RUBY_PLATFORM` may returns `x64_mingw32` (as I guess old rubies were precompiled on older CI machines). However the machines we are compiling on is `x64_mingw-ucrt`.

  I think the right fix would be to stop using `RUBY_PLATFORM` to define what platforms the gem is compatible on and instead grab the platform from something like `clang -v`.