### PR TITLE
Don't rely on `rake` from the dependency of the target gem:

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,3 +15,27 @@ jobs:
           bundler-cache: true
       - name: "Run the test suite"
         run: "bundle exec rake test"
+  gem_deps:
+    timeout-minutes: 10
+    name: "Ensure CLI is compatible no matter the gem dependencies"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          bundler-cache: true
+      - name: "Install the gem"
+        run: "rake install"
+      - name: "Bundle install on target gem"
+        working-directory: "test/fixtures/dummy_gem"
+        run: "bundle install"
+      - name: "Compile when target has rake as dependency"
+        working-directory: "test/fixtures/dummy_gem"
+        run: "easy_compile compile"
+      - name: "Compile when target gem doesn't have rake as dependency"
+        working-directory: "test/fixtures/dummy_gem"
+        run: "easy_compile compile"
+        env:
+          BUNDLE_GEMFILE: "Gemfile_no_rake"

--- a/lib/easy_compile/cli.rb
+++ b/lib/easy_compile/cli.rb
@@ -121,9 +121,13 @@ module EasyCompile
     def run_rake_tasks!(*tasks)
       all_tasks = tasks.join(" ")
       rakelibdir = File.expand_path("tasks", __dir__)
-      load_paths = Gem.loaded_specs["rake-compiler"].full_require_paths.join(":")
+      rake_compiler_path = Gem.loaded_specs["rake-compiler"].full_require_paths
+      rake_specs = Gem.loaded_specs["rake"]
+      rake_executable = rake_specs.bin_file("rake")
+      rake_path = rake_specs.full_require_paths
+      load_paths = (rake_compiler_path + rake_path).join(File::PATH_SEPARATOR)
 
-      system("bundle exec rake #{all_tasks} -I#{load_paths} -R#{rakelibdir}", exception: true)
+      system({ "RUBYLIB" => load_paths }, "bundle exec #{RbConfig.ruby} #{rake_executable} #{all_tasks} -R#{rakelibdir}", exception: true)
     end
 
     def compilation_task

--- a/test/fixtures/dummy_gem/Gemfile_no_rake
+++ b/test/fixtures/dummy_gem/Gemfile_no_rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in dummy_gem.gemspec
+gemspec
+
+gem 'minitest'

--- a/test/fixtures/dummy_gem/Gemfile_no_rake.lock
+++ b/test/fixtures/dummy_gem/Gemfile_no_rake.lock
@@ -1,0 +1,20 @@
+PATH
+  remote: .
+  specs:
+    edouard-dummy_gem (0.1.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.26.0)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  edouard-dummy_gem!
+  minitest
+
+BUNDLED WITH
+   2.7.2


### PR DESCRIPTION
- If a gem doesn't add `rake` as dependency, running `bundle exec rake` will fail.

  We need to bypass Bundler trying to find `rake` from the bundled gems by instead passing the rake executable from the EasyCompile specs.