### PR TITLE
Ruby 3.0 is incompatible for building fat gems on Windows:

### DIFF
--- a/.github/workflows/gem-compile.yml
+++ b/.github/workflows/gem-compile.yml
@@ -28,7 +28,7 @@ jobs:
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.0.7"
+          ruby-version: "3.1.7"
           bundler-cache: true
           working-directory: "test/fixtures/date"
       - name: "Run easy compile"

--- a/lib/easy_compile/ruby_series.rb
+++ b/lib/easy_compile/ruby_series.rb
@@ -37,7 +37,6 @@ module EasyCompile
         Gem::Version.new("3.3.8"),
         Gem::Version.new("3.2.8"),
         Gem::Version.new("3.1.6"),
-        Gem::Version.new("3.0.6"),
       ]
     end
 
@@ -47,7 +46,6 @@ module EasyCompile
         Gem::Version.new("3.3.9"),
         Gem::Version.new("3.2.9"),
         Gem::Version.new("3.1.7"),
-        Gem::Version.new("3.0.7"),
       ]
     end
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -115,7 +115,7 @@ module EasyCompile
         end
       end
 
-      assert_equal("3.4.6:3.3.8:3.2.8:3.1.6:3.0.6", out)
+      assert_equal("3.4.6:3.3.8:3.2.8:3.1.6", out)
     end
 
     def test_when_cli_runs_in_project_with_no_gemspec

--- a/test/fixtures/expected_github_workflow.yml
+++ b/test/fixtures/expected_github_workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.0.7"
+          ruby-version: "3.1.7"
           bundler-cache: true
       - name: "Run easy compile"
         uses: "shopify-playground/edouard-playground/.github/actions/easy_compile@main"
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
-        rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7", "3.0.7"]
+        rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
     steps:

--- a/test/fixtures/expected_github_workflow_working_dir.yml
+++ b/test/fixtures/expected_github_workflow_working_dir.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Setup Ruby"
         uses: "ruby/setup-ruby@v1"
         with:
-          ruby-version: "3.0.7"
+          ruby-version: "3.1.7"
           bundler-cache: true
           working-directory: "test/fixtures/date"
       - name: "Run easy compile"
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest"]
-        rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7", "3.0.7"]
+        rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
     steps:

--- a/test/ruby_series_test.rb
+++ b/test/ruby_series_test.rb
@@ -31,7 +31,7 @@ module EasyCompile
     def test_latest_version_for_compilation_multiple
       requirements = Gem::Requirement.new("> 3")
 
-      assert_equal("3.0.7", RubySeries.runtime_version_for_compilation(requirements).to_s)
+      assert_equal("3.1.7", RubySeries.runtime_version_for_compilation(requirements).to_s)
     end
 
     def test_versions_to_compile_against


### PR DESCRIPTION
- This is a windows specific issue. I'm modifying this for all platforms to make things simple but ultimately this should be a windows only solution. Though Ruby 3.0 is so old I don't know if it make sense to put a lot of effort into it.

  The problem being that on Ruby 3.0 for windows, the C-runtime is different than on 3.1+. So when 3.0 gets picked up for compiling the extensions for all others versions, we end up with broken binaries.

