### PR TITLE
Reduce the size of the binary generated:

### DIFF
--- a/test/fixtures/dummy_gem/ext/hello_world/extconf.rb
+++ b/test/fixtures/dummy_gem/ext/hello_world/extconf.rb
@@ -2,4 +2,6 @@
 
 require "mkmf"
 
+$LDFLAGS << " -s -pipe" if RUBY_PLATFORM !~ /darwin/
+
 create_makefile("hello_world")


### PR DESCRIPTION
- I was trying to understand why the size of the gem tarball was 10x bigger than MacOS or Windows.

  Turns out it's because when compiling on Linux, the debugging symbols aren't stripped out.

  I'm wondering if this is something the tool should automatically do.