### PR TITLE
Fix precompiled gem not working on a different linux machine:

### DIFF
--- a/.github/actions/easy_compile/dist/index.js
+++ b/.github/actions/easy_compile/dist/index.js
@@ -28274,7 +28274,7 @@ function rubyBuilderURL(rubyVersion) {
   let platform = os.platform();
 
   if (platform == "linux") {
-    platform = "ubuntu-24.04"; // Not great but this is a quick workaround
+    platform = "ubuntu-22.04"; // Not great but this is a quick workaround
   }
 
   return `${rubyReleasesUrl}/ruby-${rubyVersion}/ruby-${rubyVersion}-${platform}-${os.arch()}.tar.gz`;

--- a/.github/actions/easy_compile/src/index.js
+++ b/.github/actions/easy_compile/src/index.js
@@ -73,7 +73,7 @@ function rubyBuilderURL(rubyVersion) {
   let platform = os.platform();
 
   if (platform == "linux") {
-    platform = "ubuntu-24.04"; // Not great but this is a quick workaround
+    platform = "ubuntu-22.04"; // Not great but this is a quick workaround
   }
 
   return `${rubyReleasesUrl}/ruby-${rubyVersion}/ruby-${rubyVersion}-${platform}-${os.arch()}.tar.gz`;

--- a/.github/workflows/e2e-dummy-gem.yml
+++ b/.github/workflows/e2e-dummy-gem.yml
@@ -6,7 +6,7 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"
@@ -29,7 +29,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
         rubies: ["3.4.7", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -54,7 +54,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"

--- a/.github/workflows/gem-compile.yml
+++ b/.github/workflows/gem-compile.yml
@@ -14,14 +14,14 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Install gperf"
         if: ${{ matrix.os == 'windows-latest' }}
         run: choco install gperf
       - name: "Install gperf"
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get -qy install gperf
       - name: "Checkout code"
         uses: "actions/checkout@v5"
@@ -43,7 +43,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
         rubies: ["3.4.7", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -68,7 +68,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Setup Ruby"

--- a/lib/easy_compile/cli.rb
+++ b/lib/easy_compile/cli.rb
@@ -93,7 +93,7 @@ module EasyCompile
     method_option "test-command", type: "string", required: false, desc: "The test command to run. Defaults to running `bundle exec rake test` and `bundle exec rake spec`."
     def ci_template
       # os = ["macos-latest", "macos-15-intel", "ubuntu-latest", "windows-latest"]
-      os = ["macos-latest", "ubuntu-latest"] # Just this for now because the CI takes too long otherwise.
+      os = ["macos-latest", "ubuntu-22.04"] # Just this for now because the CI takes too long otherwise.
 
       ruby_requirements = compilation_task.gemspec.required_ruby_version
       latest_supported_ruby_version = RubySeries.latest_version_for_requirements(ruby_requirements)

--- a/test/fixtures/expected_github_workflow.yml
+++ b/test/fixtures/expected_github_workflow.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"
@@ -34,7 +34,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
         rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -57,7 +57,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Setup Ruby"

--- a/test/fixtures/expected_github_workflow_test_and_workdir.yml
+++ b/test/fixtures/expected_github_workflow_test_and_workdir.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"
@@ -36,7 +36,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
         rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -62,7 +62,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Setup Ruby"

--- a/test/fixtures/expected_github_workflow_test_command.yml
+++ b/test/fixtures/expected_github_workflow_test_command.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"
@@ -34,7 +34,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
         rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -58,7 +58,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Setup Ruby"

--- a/test/fixtures/expected_github_workflow_working_dir.yml
+++ b/test/fixtures/expected_github_workflow_working_dir.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"
@@ -36,7 +36,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
         rubies: ["3.4.7", "3.3.9", "3.2.9", "3.1.7"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -61,7 +61,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Setup Ruby"


### PR DESCRIPTION
Fix precompiled gem not working on a different linux machine:

- I tried installing a gem precompiled on a CI machine in a completely different environment and the binary doesn't work.

  I have two different problems:

  1. Same as on MacOS where `libruby.so` is linked on a path that doesn't exist. I fixed the issue the same way as I did on MacOS but tweaked the logic to modify the makfile (the previous regex wouldn't work if `-l$(LIBRUBYSO)` was in between other flags).
  2. This one is more tricky and the solution is a bandaid. On ubuntu-24.04 (ubuntu-latest), the glibc version is 2.38, and it's relatively new. Any system using a older glibc version will not be able to use the precompiled binaries because glibc versions aren't backward compatible.

     In this commit, I modified the GitHub runner to use ubuntu 22.04, which has glibc to 2.35. This should allow slighltly older linux versions to install our precompiled gems.

     Ultimately, glibc 2.35 may still be too recent (released on 2022-02), and maybe a more acceptable version should be glibc 2.31 which was released in 2020. At least that's what Rake Compiler Dock uses and I haven't seen people complaining that they'd like the precompiled gems to support even older linux distro.

     We can't downgrade glibc to version 2.31, it will crash the CI machine. So I don't think we have any other way but to build a docker image and do the compilation in docker.