### PR TITLE
Parse the extconf instead of running it:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     easy_compile (0.1.1)
+      prism
       rake-compiler
       thor
 
@@ -9,6 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (5.25.5)
+    prism (1.6.0)
     rake (13.3.0)
     rake-compiler (1.3.0)
       rake

--- a/easy_compile.gemspec
+++ b/easy_compile.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake-compiler"
   spec.add_dependency "thor"
+  spec.add_dependency "prism"
 end

--- a/lib/easy_compile/cli.rb
+++ b/lib/easy_compile/cli.rb
@@ -134,7 +134,8 @@ module EasyCompile
       rake_specs = Gem.loaded_specs["rake"]
       rake_executable = rake_specs.bin_file("rake")
       rake_path = rake_specs.full_require_paths
-      load_paths = (rake_compiler_path + rake_path).join(File::PATH_SEPARATOR)
+      prism_path = Gem.loaded_specs["prism"].full_require_paths
+      load_paths = (rake_compiler_path + rake_path + prism_path).join(File::PATH_SEPARATOR)
 
       system({ "RUBYLIB" => load_paths }, "bundle exec #{RbConfig.ruby} #{rake_executable} #{all_tasks} -R#{rakelibdir}", exception: true)
     end

--- a/lib/easy_compile/create_makefile_finder.rb
+++ b/lib/easy_compile/create_makefile_finder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module EasyCompile
+  class CreateMakefileFinder < Prism::Visitor
+    attr_reader :binary_name
+
+    def visit_call_node(node)
+      super
+      looking_for = [:create_makefile, :create_rust_makefile]
+      return unless looking_for.include?(node.name)
+
+      @binary_name = node.arguments.child_nodes.first.content
+    end
+  end
+end


### PR DESCRIPTION
Parse the extconf instead of running it:

- Loading the extconf.rb file was required as we need to be able to detect the `create_makefile` call in order to know the resultin binary name (the first argument to the method). We need to know the resulting binary name in order to properly setup rake compiler.

  Running the extconf was really hacky so instead we'll parse it with Prism.