### PR TITLE
Hook onto the `gem` task instead of `package`:

### DIFF
--- a/lib/cibuildgem/tasks/wrapper.rake
+++ b/lib/cibuildgem/tasks/wrapper.rake
@@ -2,7 +2,7 @@
 
 require_relative "../compilation_tasks"
 
-task = Cibuildgem::CompilationTasks.new(!Rake::Task.task_defined?(:package))
+task = Cibuildgem::CompilationTasks.new(!Rake::Task.task_defined?(:gem))
 
 task "cibuildgem:setup" do
   Rake.application.instance_variable_get(:@tasks).delete_if do |name, _|


### PR DESCRIPTION
- The package and gem task both gets defined by RubyGems using the `PackageTask` module. Some gems have a `package` task defined manually, but cibuildgem won't call this task (it calls `gem` because that's what Rake Compiler relies on).

  This change checks whether a `gem` task is defined, and it not create it in order to package a gem version with no precompiled binary.