### PR TITLE
Prevent rake compiler from defining application defined task:

### DIFF
--- a/lib/cibuildgem/cli.rb
+++ b/lib/cibuildgem/cli.rb
@@ -137,8 +137,13 @@ module Cibuildgem
       rake_path = rake_specs.full_require_paths
       prism_path = Gem.loaded_specs["prism"].full_require_paths
       load_paths = (rake_compiler_path + rake_path + prism_path).join(File::PATH_SEPARATOR)
+      patch = File.expand_path("../extension_patch.rb", __FILE__)
 
-      system({ "RUBYLIB" => load_paths }, "bundle exec #{RbConfig.ruby} #{rake_executable} #{all_tasks} -R#{rakelibdir}", exception: true)
+      system(
+        { "RUBYLIB" => load_paths },
+        "bundle exec #{RbConfig.ruby} #{rake_executable} #{all_tasks} -R#{rakelibdir} -r #{patch}",
+        exception: true,
+      )
     end
 
     def compilation_task

--- a/lib/cibuildgem/compilation_tasks.rb
+++ b/lib/cibuildgem/compilation_tasks.rb
@@ -17,6 +17,8 @@ module Cibuildgem
     end
 
     def setup
+      Rake::ExtensionTask.enable!
+
       gemspec.extensions.each do |path|
         binary_name = parse_extconf(path)
         define_task(path, binary_name)

--- a/lib/cibuildgem/extension_patch.rb
+++ b/lib/cibuildgem/extension_patch.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rake/extensiontask"
+
+module Cibuildgem
+  module ExtensionPatch
+    class << self
+      def prepended(mod)
+        class << mod
+          attr_accessor :enabled
+
+          def enable!
+            @enabled = true
+          end
+        end
+      end
+    end
+
+    def define
+      super if self.class.enabled
+    end
+  end
+end
+
+Rake::ExtensionTask.prepend(Cibuildgem::ExtensionPatch)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "English"
 
 module Cibuildgem
   class CLITest < Minitest::Test
@@ -212,6 +213,14 @@ module Cibuildgem
           end
         end
       end
+    end
+
+    def test_package_when_a_rakefile_defines_an_extension_task
+      Dir.chdir("test/fixtures/with_ext") do
+        CLI.start(["package"])
+      end
+
+      assert_predicate($CHILD_STATUS, :success?)
     end
 
     private

--- a/test/fixtures/with_ext/Rakefile
+++ b/test/fixtures/with_ext/Rakefile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rake/extensiontask"
+
+gemspec = Gem::Specification.load("foo.gemspec")
+Rake::ExtensionTask.new("foo", gemspec)
+
+raise "No rake task should have been defined" if Rake::Task.task_defined?(:native)
+
+exit(0)

--- a/test/fixtures/with_ext/foo.gemspec
+++ b/test/fixtures/with_ext/foo.gemspec
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "edouard-dummy_gem"
+  spec.version = "0.0.1"
+  spec.authors = ["Edouard CHIN"]
+  spec.email = ["user@example.org"]
+  spec.summary = "A gem that do nothing"
+  spec.description = "Don't use it, really."
+  spec.license = "MIT"
+  spec.files = []
+  spec.require_paths = ["lib"]
+  spec.extensions = ["ext/hello_world/extconf.rb"]
+end


### PR DESCRIPTION
- Gem that define a Rake Compiler task (pretty much all) interfere with our own. The reason we can't rely on the user defined task is because it's not configured for compiling fat gems, it is usually only configured to compile natively for development purposes.

  I also would like the configuration of cibuildgem to not interfere with the gem defined task and not have to ask maintainers to change basic configuration just to make compiling fat gems possible, cibuildgem should take care of this automatically.

  For reference, I originally decided to choose running the whole compilation dance in a subprocess and require the gem Rakefile because I felt this would be the right entrypoint to configure CIbuildgem if needed.