### PR TITLE
Setup compilation task before testing:

### DIFF
--- a/lib/cibuildgem/cli.rb
+++ b/lib/cibuildgem/cli.rb
@@ -2,6 +2,7 @@
 
 require "thor"
 require "rake/extensiontask"
+require "prism"
 
 module Cibuildgem
   class CLI < Thor
@@ -54,7 +55,7 @@ module Cibuildgem
       cibuildgem will run the test suite of the gem. It either expects a `spec` or `test` task defined.
     EOM
     def test
-      run_rake_tasks!(:test)
+      run_rake_tasks!("cibuildgem:setup", :test)
     end
 
     desc "copy_from_staging_to_lib", "Copy the staging binary. For internal usage.", hide: true

--- a/test/fixtures/no_test_task_defined/foo.gemspec
+++ b/test/fixtures/no_test_task_defined/foo.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.files = []
   spec.require_paths = ["lib"]
-  spec.extensions = ["ext/foo.rb"]
+  spec.extensions = ["foo.rb"]
 end

--- a/test/fixtures/no_test_task_defined/foo.rb
+++ b/test/fixtures/no_test_task_defined/foo.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+create_makefile("foo")

--- a/test/fixtures/spec_task_defined/foo.gemspec
+++ b/test/fixtures/spec_task_defined/foo.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.files = []
   spec.require_paths = ["lib"]
-  spec.extensions = ["ext/foo.rb"]
+  spec.extensions = ["foo.rb"]
 end

--- a/test/fixtures/spec_task_defined/foo.rb
+++ b/test/fixtures/spec_task_defined/foo.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+create_makefile("foo")

--- a/test/fixtures/test_task_defined/foo.gemspec
+++ b/test/fixtures/test_task_defined/foo.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |spec|
 
   spec.files = []
   spec.require_paths = ["lib"]
-  spec.extensions = ["ext/foo.rb"]
+  spec.extensions = ["foo.rb"]
 end

--- a/test/fixtures/test_task_defined/foo.rb
+++ b/test/fixtures/test_task_defined/foo.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+create_makefile("foo")


### PR DESCRIPTION
- Some gems have a `compile` prerequisite, before the `test` task. Even though running the compilation when the test starts in the context of cibuildgem is not really required (since the binary gets uploaded during the compilation phase and is downloaded in the machine that runs the test suite), but I'd rather have it work out of the box rather than ask maintainers to create a separate rake task that don't have a prerequisite `compile` (since in development having it is actually useful).