### PR TITLE
Strip debugging symbols:

### DIFF
--- a/lib/cibuildgem/compilation_tasks.rb
+++ b/lib/cibuildgem/compilation_tasks.rb
@@ -92,6 +92,17 @@ module Cibuildgem
 
             File.write(task.name, makefile_content)
           end
+
+          makefile_content.match(/^ldflags\W+=(.*)/) do |match|
+            ldflags = match[1].split(" ")
+            next if ldflags.include?("-s")
+
+            ldflags << "-s"
+
+            makefile_content.gsub!(/^(ldflags\W+=)(.*)/, "\\1#{ldflags.join(" ")}")
+
+            File.write(task.name, makefile_content)
+          end
         end
       end
     end

--- a/test/fixtures/dummy_gem/ext/hello_world/extconf.rb
+++ b/test/fixtures/dummy_gem/ext/hello_world/extconf.rb
@@ -2,6 +2,4 @@
 
 require "mkmf"
 
-$LDFLAGS << " -s -pipe" if RUBY_PLATFORM !~ /darwin/ # rubocop:disable Style/GlobalVars
-
 create_makefile("hello_world")


### PR DESCRIPTION
- Debugging symbols makes binary size way too big.