### PR TITLE
Preference the `RUBY_CC_VERSION` ENV if present:

### DIFF
--- a/lib/cibuildgem/cli.rb
+++ b/lib/cibuildgem/cli.rb
@@ -119,7 +119,7 @@ module Cibuildgem
     desc "print_ruby_cc_version", "Output the cross compile ruby version needed for the gem. For internal usage", hide: true
     method_option "gemspec", type: "string", required: false, desc: "The gemspec to use. If the option is not passed, a gemspec file from the current working directory will be used."
     def print_ruby_cc_version
-      print(compilation_task.ruby_cc_version)
+      print(ENV["RUBY_CC_VERSION"] || compilation_task.ruby_cc_version)
     end
 
     desc "normalized_platform", "The platform name for compilation purposes", hide: true

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -151,6 +151,20 @@ module Cibuildgem
       assert_equal("4.0.0:3.4.6:3.3.8:3.2.8:3.1.6", out)
     end
 
+    def test_print_ruby_cc_version_env_has_precedence
+      ENV["RUBY_CC_VERSION"] = "3.1:3.2"
+
+      out, _ = capture_subprocess_io do
+        Dir.chdir("test/fixtures/dummy_gem") do
+          CLI.start(["print_ruby_cc_version"])
+        end
+      end
+
+      assert_equal("3.1:3.2", out)
+    ensure
+      ENV.delete("RUBY_CC_VERSION")
+    end
+
     def test_when_cli_runs_in_project_with_no_gemspec
       out = nil
 


### PR DESCRIPTION
- This allow users to define what ruby version will get downloaded by the GitHub action. Without this feature, the GitHub action will download all minor ruby versions the gem is compatible with.