### PR TITLE
Add a CIBUILDGEM env when running GitHub workflow:

### DIFF
--- a/lib/cibuildgem/templates/github/workflows/cibuildgem.yaml.tt
+++ b/lib/cibuildgem/templates/github/workflows/cibuildgem.yaml.tt
@@ -7,6 +7,8 @@ on:
         required: false
         type: boolean
         default: false
+env:
+  CIBUILDGEM: 1
 jobs:
   compile:
     timeout-minutes: 20

--- a/test/fixtures/expected_github_workflow.yml
+++ b/test/fixtures/expected_github_workflow.yml
@@ -7,6 +7,8 @@ on:
         required: false
         type: boolean
         default: false
+env:
+  CIBUILDGEM: 1
 jobs:
   compile:
     timeout-minutes: 20

--- a/test/fixtures/expected_github_workflow_test_and_workdir.yml
+++ b/test/fixtures/expected_github_workflow_test_and_workdir.yml
@@ -7,6 +7,8 @@ on:
         required: false
         type: boolean
         default: false
+env:
+  CIBUILDGEM: 1
 jobs:
   compile:
     timeout-minutes: 20

--- a/test/fixtures/expected_github_workflow_test_command.yml
+++ b/test/fixtures/expected_github_workflow_test_command.yml
@@ -7,6 +7,8 @@ on:
         required: false
         type: boolean
         default: false
+env:
+  CIBUILDGEM: 1
 jobs:
   compile:
     timeout-minutes: 20

--- a/test/fixtures/expected_github_workflow_working_dir.yml
+++ b/test/fixtures/expected_github_workflow_working_dir.yml
@@ -7,6 +7,8 @@ on:
         required: false
         type: boolean
         default: false
+env:
+  CIBUILDGEM: 1
 jobs:
   compile:
     timeout-minutes: 20


### PR DESCRIPTION
- This allow users to modify their Rakefile and perform logic dependending on whether we are running in the context of cibuildgem.