### PR TITLE
Speed up the test suite:

### DIFF
--- a/.github/workflows/e2e-dummy-gem.yml
+++ b/.github/workflows/e2e-dummy-gem.yml
@@ -6,7 +6,7 @@ jobs:
     name: "Cross compile the gem on different ruby versions"
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
+        os: ["ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"
@@ -28,7 +28,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
+        os: ["ubuntu-22.04"]
         rubies: ["3.1", "3.4"]
         type: ["cross", "native"]
     runs-on: "${{ matrix.os }}"
@@ -52,7 +52,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-22.04", "windows-latest"]
+        os: ["ubuntu-22.04"]
     runs-on: "${{ matrix.os }}"
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
- The point of the end to end test is to make sure the cibuildgem GitHub action works. We don't need to test on multiple platform.