### PR TITLE
Keep the gem task configured:

### DIFF
--- a/lib/cibuildgem/compilation_tasks.rb
+++ b/lib/cibuildgem/compilation_tasks.rb
@@ -17,8 +17,6 @@ module Cibuildgem
     end
 
     def setup
-      Rake::ExtensionTask.enable!
-
       gemspec.extensions.each do |path|
         binary_name = parse_extconf(path)
         define_task(path, binary_name)
@@ -54,16 +52,19 @@ module Cibuildgem
     end
 
     def define_task(path, binary_name)
-      @extension_task = Rake::ExtensionTask.new do |ext|
-        ext.name = File.basename(binary_name)
-        ext.config_script = File.basename(path)
-        ext.ext_dir = File.dirname(path)
-        ext.lib_dir = binary_lib_dir(binary_name) if binary_lib_dir(binary_name)
-        ext.gem_spec = gemspec
-        ext.cross_platform = normalized_platform
-        ext.cross_compile = true
-        ext.no_native = true
-      end
+      @extension_task = Rake::ExtensionTask.current || Rake::ExtensionTask.new
+
+      @extension_task.name = File.basename(binary_name)
+      @extension_task.config_script = File.basename(path)
+      @extension_task.ext_dir = File.dirname(path)
+      @extension_task.lib_dir = binary_lib_dir(binary_name) if binary_lib_dir(binary_name)
+      @extension_task.gem_spec = gemspec
+      @extension_task.cross_platform = normalized_platform
+      @extension_task.cross_compile = true
+      @extension_task.no_native = true
+
+      Rake::ExtensionTask.enable!
+      @extension_task.define
 
       disable_shared unless Gem.win_platform?
     end

--- a/lib/cibuildgem/extension_patch.rb
+++ b/lib/cibuildgem/extension_patch.rb
@@ -7,13 +7,19 @@ module Cibuildgem
     class << self
       def prepended(mod)
         class << mod
-          attr_accessor :enabled
+          attr_accessor :enabled, :current
 
           def enable!
             @enabled = true
           end
         end
       end
+    end
+
+    def initialize(*)
+      super
+
+      self.class.current = self
     end
 
     def define

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -243,6 +243,18 @@ module Cibuildgem
       assert_predicate($CHILD_STATUS, :success?)
     end
 
+    def test_keep_the_extension_task_config_defined_by_the_gem
+      Dir.chdir("test/fixtures/with_configured_ext") do
+        cli = CLI.new
+
+        out, _ = capture_subprocess_io do
+          cli.send(:run_rake_tasks!, :foo)
+        end
+
+        assert_equal("foo bar", out)
+      end
+    end
+
     private
 
     def raise_instead_of_exit(&block)

--- a/test/fixtures/with_configured_ext/Rakefile
+++ b/test/fixtures/with_configured_ext/Rakefile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rake/extensiontask"
+
+gemspec = Gem::Specification.load("foo.gemspec")
+Rake::ExtensionTask.new("foo", gemspec) do |t|
+  t.cross_config_options = ["foo", "bar"]
+end
+
+task :foo do
+  task = Cibuildgem::CompilationTasks.new(!Rake::Task.task_defined?(:gem))
+  task.setup
+
+  print task.extension_task.cross_config_options.join(" ")
+end

--- a/test/fixtures/with_configured_ext/extconf.rb
+++ b/test/fixtures/with_configured_ext/extconf.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+create_makefile("foo")

--- a/test/fixtures/with_configured_ext/foo.gemspec
+++ b/test/fixtures/with_configured_ext/foo.gemspec
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "edouard-dummy_gem"
+  spec.version = "0.0.1"
+  spec.authors = ["Edouard CHIN"]
+  spec.email = ["user@example.org"]
+  spec.summary = "A gem that do nothing"
+  spec.description = "Don't use it, really."
+  spec.license = "MIT"
+  spec.files = []
+  spec.require_paths = ["lib"]
+  spec.extensions = ["extconf.rb"]
+end


### PR DESCRIPTION
- It's quite common for gem to have a Rakefile that already define an ExtensionTask for development purpose.

  This ExtensionTask is configured but cibuildgem would override it. Now, cibuildgem will keep the configuration untouched, but will tweak the task for compiling fat gems.