### PR TITLE
Development purpose only:

### DIFF
--- a/lib/cibuildgem/tasks/wrapper.rake
+++ b/lib/cibuildgem/tasks/wrapper.rake
@@ -12,11 +12,9 @@ task "cibuildgem:setup" do
 end
 
 task "copy:stage:lib" do
-  version = RUBY_VERSION.match(/(\d\.\d)/)[1]
-  dest = File.join(task.extension_task.lib_dir, version)
-  src = File.join("tmp", task.extension_task.cross_platform, "stage", dest)
+  src = File.join("tmp", task.extension_task.cross_platform, "stage")
 
-  cp_r(src, dest, remove_destination: true)
+  cp_r(Dir.glob("#{src}/*"), ".", remove_destination: true)
 end
 
 unless Rake::Task.task_defined?(:test)

--- a/test/fixtures/date/Rakefile
+++ b/test/fixtures/date/Rakefile
@@ -8,7 +8,7 @@ CLEAN.include("**/*.o", "**/*.so", "**/*.bundle", "*.jar", "pkg", "tmp")
 
 extask = Rake::ExtensionTask.new("date") do |ext|
   ext.name = "date_core"
-  ext.lib_dir.sub!(%r[(?=/|\z)], "/#{RUBY_VERSION}/#{ext.platform}")
+  ext.lib_dir.sub!(%r[(?=/|\z)], "/#{ext.platform}")
 end
 
 Rake::TestTask.new(:test) do |t|


### PR DESCRIPTION
Copy stating files to the root of the project:

- The previous code would not work when a gem Rakefile includes a compiler task that has a dynamic `lib_dir`.

  For instance:

  ```ruby
  Rake::ExtensionTask.new("date") do |ext|
    ext.lib_dir = "lib/#{RUBY_VERSION}"
  end
  ```

  In this case, when the compilation starts, the runtime ruby would be on Ruby 3.1.7, so the binaries would be located in `tmp/stage/lib/3.1.7/3.4/date.so`.

Then once we want to try running the test suite for Ruby 3.4, we'd evaluate the ExtensionTask again and we'd try to copy `tmp/stage/lib/3.4.7/3.4/date.so` which doesn't exist.

The fix in this patch is to copy everything in the `tmp/stage/*` folder at the root of the repo.