### PR TITLE
Build Linux gems in rake-compiler-dock containers

### DIFF
--- a/.github/actions/cibuildgem/action.yml
+++ b/.github/actions/cibuildgem/action.yml
@@ -47,6 +47,7 @@ runs:
       env:
         CIBUILDGEM_CONTAINER_IMAGE: "${{ inputs.linux-container-image }}"
         CIBUILDGEM_VERSION: "${{ inputs.version }}"
+        CIBUILDGEM_SOURCE_PATH: "${{ endsWith(github.repository, '/cibuildgem') && github.workspace || '' }}"
       run: cibuildgem container_package
     - name: Package
       if: "${{ inputs.step == 'compile' && runner.os != 'Linux' }}"
@@ -77,6 +78,7 @@ runs:
       env:
         CIBUILDGEM_CONTAINER_IMAGE: "${{ inputs.linux-container-image }}"
         CIBUILDGEM_VERSION: "${{ inputs.version }}"
+        CIBUILDGEM_SOURCE_PATH: "${{ endsWith(github.repository, '/cibuildgem') && github.workspace || '' }}"
         CIBUILDGEM_CONTAINER_COMMAND: |-
           cibuildgem copy_from_staging_to_lib
           ${{ inputs.test-command }}
@@ -109,6 +111,7 @@ runs:
       env:
         CIBUILDGEM_CONTAINER_IMAGE: "${{ inputs.linux-container-image }}"
         CIBUILDGEM_VERSION: "${{ inputs.version }}"
+        CIBUILDGEM_SOURCE_PATH: "${{ endsWith(github.repository, '/cibuildgem') && github.workspace || '' }}"
         CIBUILDGEM_CONTAINER_COMMAND: "gem install pkg/*.gem"
       run: cibuildgem container_exec
     - name: "Download all gems"

--- a/.github/actions/cibuildgem/action.yml
+++ b/.github/actions/cibuildgem/action.yml
@@ -16,6 +16,9 @@ inputs:
   version:
     description: "The version of the cibuildgem ruby gem to use. Defaults to the latest version."
     required: false
+  linux-container-image:
+    description: "Override the Linux container image used for containerized Linux steps. Defaults to the rake-compiler-dock image for the target platform."
+    required: false
 
 runs:
   using: "composite"
@@ -24,21 +27,29 @@ runs:
       shell: bash
       run: |-
         ${{ case(
-          github.repository == 'Shopify/cibuildgem', 'rake install',
           inputs.version != null, format('gem install cibuildgem -v {0}', inputs.version),
+          github.repository == 'Shopify/cibuildgem', 'rake install',
           'gem install cibuildgem'
         ) }}
       working-directory: "${{ github.action_path }}"
     - name: "Setup Rake Compiler"
-      if: "${{ inputs.step == 'compile' }}"
+      if: "${{ inputs.step == 'compile' && runner.os != 'Linux' }}"
       uses: actions/github-script@v8
       with:
         script: |
           const url = new URL(`file:///${process.env.GITHUB_ACTION_PATH}/dist/index.js`);
           const { run } = await import(url.href)
           await run('${{ inputs.working-directory }}')
+    - name: "Package in Linux container"
+      if: "${{ inputs.step == 'compile' && runner.os == 'Linux' }}"
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        CIBUILDGEM_CONTAINER_IMAGE: "${{ inputs.linux-container-image }}"
+        CIBUILDGEM_VERSION: "${{ inputs.version }}"
+      run: cibuildgem container_package
     - name: Package
-      if: "${{ inputs.step == 'compile' }}"
+      if: "${{ inputs.step == 'compile' && runner.os != 'Linux' }}"
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: cibuildgem package
@@ -59,8 +70,19 @@ runs:
       with:
         name: "stage-${{ runner.os }}-${{ runner.arch }}"
         path: "${{ inputs.working-directory }}"
+    - name: "Execute cross tests in Linux container"
+      if: "${{ inputs.step == 'test_cross' && runner.os == 'Linux' }}"
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        CIBUILDGEM_CONTAINER_IMAGE: "${{ inputs.linux-container-image }}"
+        CIBUILDGEM_VERSION: "${{ inputs.version }}"
+        CIBUILDGEM_CONTAINER_COMMAND: |-
+          cibuildgem copy_from_staging_to_lib
+          ${{ inputs.test-command }}
+      run: cibuildgem container_exec --bundle-install
     - name: "Copy staging binary to the libdir"
-      if: "${{ inputs.step == 'test_cross' }}"
+      if: "${{ inputs.step == 'test_cross' && runner.os != 'Linux' }}"
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: cibuildgem copy_from_staging_to_lib
@@ -70,7 +92,7 @@ runs:
       shell: bash
       run: cibuildgem compile
     - name: "Execute the tests"
-      if: "${{ startsWith(inputs.step, 'test') }}"
+      if: "${{ startsWith(inputs.step, 'test') && !(inputs.step == 'test_cross' && runner.os == 'Linux') }}"
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: ${{ inputs.test-command }}
@@ -79,14 +101,25 @@ runs:
       uses: actions/download-artifact@v5
       with:
         name: "stage-${{ runner.os }}-${{ runner.arch }}"
+        path: "${{ inputs.working-directory }}"
+    - name: "Install gems in Linux container"
+      if: "${{ inputs.step == 'install' && runner.os == 'Linux' }}"
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        CIBUILDGEM_CONTAINER_IMAGE: "${{ inputs.linux-container-image }}"
+        CIBUILDGEM_VERSION: "${{ inputs.version }}"
+        CIBUILDGEM_CONTAINER_COMMAND: "gem install pkg/*.gem"
+      run: cibuildgem container_exec
     - name: "Download all gems"
       if: "${{ inputs.step == 'release' }}"
       uses: actions/download-artifact@v5
       with:
         merge-multiple: true
     - name: "Install gems"
-      if: "${{ inputs.step == 'install' }}"
+      if: "${{ inputs.step == 'install' && runner.os != 'Linux' }}"
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: gem install pkg/*.gem
     - name: "Configure RubyGems crendentials in preparation for publishing"
       if: "${{ inputs.step == 'release' }}"

--- a/.github/actions/cibuildgem/action.yml
+++ b/.github/actions/cibuildgem/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |-
         ${{ case(
           inputs.version != null, format('gem install cibuildgem -v {0}', inputs.version),
-          github.repository == 'Shopify/cibuildgem', 'rake install',
+          endsWith(github.repository, '/cibuildgem'), 'rake install',
           'gem install cibuildgem'
         ) }}
       working-directory: "${{ github.action_path }}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      rake-compiler:
+        patterns:
+          - "rake-compiler"
+          - "rake-compiler-dock"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/date-gem-compile.yml
+++ b/.github/workflows/date-gem-compile.yml
@@ -79,6 +79,7 @@ jobs:
         uses: "./.github/actions/cibuildgem"
         with:
           step: "install"
+          working-directory: "test/fixtures/date"
 
   # Make sure the precompiled binary doesn't use glibc symbols newer than 2.17. See issue #37.
   glibc_compat:

--- a/.github/workflows/date-gem-compile.yml
+++ b/.github/workflows/date-gem-compile.yml
@@ -79,6 +79,48 @@ jobs:
         uses: "./.github/actions/cibuildgem"
         with:
           step: "install"
+
+  # Make sure the precompiled binary doesn't use glibc symbols newer than 2.17. See issue #37.
+  glibc_compat:
+    timeout-minutes: 5
+    name: "Check glibc symbol versions on the precompiled date binary"
+    needs: compile
+    runs-on: "ubuntu-22.04"
+    env:
+      MAX_ALLOWED_GLIBC: "2.17"
+    steps:
+      - name: "Download the staged Linux artifacts"
+        uses: actions/download-artifact@v5
+        with:
+          name: "stage-Linux-X64"
+          path: "stage"
+      - name: "Inspect glibc symbol versions"
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          binaries=(stage/**/*.so)
+          if [ ${#binaries[@]} -eq 0 ]; then
+            echo "::error::No .so files found in the stage artifact"
+            exit 1
+          fi
+
+          fail=0
+          for binary in "${binaries[@]}"; do
+            echo "::group::$binary"
+            symbols_file="$binary.glibc.txt"
+            objdump -T "$binary" | awk '/GLIBC_/{print $5}' | sort -u > "$symbols_file"
+            cat "$symbols_file"
+            while IFS= read -r ver; do
+              ver_num=${ver#GLIBC_}
+              if [ "$(printf '%s\n%s\n' "$ver_num" "$MAX_ALLOWED_GLIBC" | sort -V | tail -n1)" != "$MAX_ALLOWED_GLIBC" ]; then
+                echo "::error file=$binary::References $ver, newer than allowed GLIBC_$MAX_ALLOWED_GLIBC"
+                fail=1
+              fi
+            done < "$symbols_file"
+            echo "::endgroup::"
+          done
+          exit $fail
   release:
     permissions:
       id-token: write

--- a/.github/workflows/e2e-dummy-gem.yml
+++ b/.github/workflows/e2e-dummy-gem.yml
@@ -65,3 +65,45 @@ jobs:
         uses: "./.github/actions/cibuildgem"
         with:
           step: "install"
+
+  # Make sure the precompiled binary doesn't use glibc symbols newer than 2.17. See issue #37.
+  glibc_compat:
+    timeout-minutes: 5
+    name: "Check glibc symbol versions on the precompiled Linux binary"
+    needs: compile
+    runs-on: "ubuntu-22.04"
+    env:
+      MAX_ALLOWED_GLIBC: "2.17"
+    steps:
+      - name: "Download the staged Linux artifacts"
+        uses: actions/download-artifact@v5
+        with:
+          name: "stage-Linux-X64"
+          path: "stage"
+      - name: "Inspect glibc symbol versions"
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s globstar nullglob
+          binaries=(stage/**/*.so)
+          if [ ${#binaries[@]} -eq 0 ]; then
+            echo "::error::No .so files found in the stage artifact"
+            exit 1
+          fi
+
+          fail=0
+          for binary in "${binaries[@]}"; do
+            echo "::group::$binary"
+            symbols_file="$binary.glibc.txt"
+            objdump -T "$binary" | awk '/GLIBC_/{print $5}' | sort -u > "$symbols_file"
+            cat "$symbols_file"
+            while IFS= read -r ver; do
+              ver_num=${ver#GLIBC_}
+              if [ "$(printf '%s\n%s\n' "$ver_num" "$MAX_ALLOWED_GLIBC" | sort -V | tail -n1)" != "$MAX_ALLOWED_GLIBC" ]; then
+                echo "::error file=$binary::References $ver, newer than allowed GLIBC_$MAX_ALLOWED_GLIBC"
+                fail=1
+              fi
+            done < "$symbols_file"
+            echo "::endgroup::"
+          done
+          exit $fail

--- a/.github/workflows/e2e-dummy-gem.yml
+++ b/.github/workflows/e2e-dummy-gem.yml
@@ -65,6 +65,7 @@ jobs:
         uses: "./.github/actions/cibuildgem"
         with:
           step: "install"
+          working-directory: "test/fixtures/dummy_gem"
 
   # Make sure the precompiled binary doesn't use glibc symbols newer than 2.17. See issue #37.
   glibc_compat:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /.github/actions/cibuildgem/node_modules
+test/fixtures/**/*.so
+test/fixtures/**/*.bundle
+test/fixtures/**/*.dylib

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     cibuildgem (0.3.0)
       prism
       rake-compiler
+      rake-compiler-dock (~> 1.12)
       thor
 
 GEM
@@ -24,6 +25,7 @@ GEM
     rake (13.3.0)
     rake-compiler (1.3.0)
       rake
+    rake-compiler-dock (1.12.0)
     regexp_parser (2.11.3)
     rubocop (1.81.7)
       json (~> 2.3)

--- a/README.md
+++ b/README.md
@@ -46,3 +46,23 @@ Here are some working examples on gem that have setup cibuildgem
 | Ruby 3.3| 🟢           | 🟢        | 🟢          | 🟢             | 🟢             |
 | Ruby 3.4| 🟢           | 🟢        | 🟢          | 🟢             | 🟢             |
 | Ruby 4.0| 🟢           | 🟢        | 🟠 (not tested)| 🟢             | 🟢             |
+
+## Linux containerized builds
+
+Linux compile, test-cross and install steps run in [`rake-compiler-dock`](https://github.com/rake-compiler/rake-compiler-dock) containers. Keeps glibc stable across `ubuntu-latest` upgrades.
+
+The default image is rake-compiler-dock's pick for your platform. To use a different one, pass `linux-container-image:` to the action or `--linux-container-image` to `cibuildgem ci_template`.
+
+### Reproducing the Linux flow locally
+
+Test the Linux build locally with Podman or Docker:
+
+```sh
+bundle exec exe/cibuildgem container_package --working-directory path/to/gem
+```
+
+`test/fixtures/dummy_gem` is the quickest test case. Override with `--container-image` or `CIBUILDGEM_CONTAINER_IMAGE`. Pin cibuildgem version with `CIBUILDGEM_VERSION`.
+
+### Linux musl / aarch64
+
+rake-compiler-dock has images for `x86_64-linux-gnu`, `x86_64-linux-musl`, `aarch64-linux-gnu`, `aarch64-linux-musl`. cibuildgem handles them transparently. The default matrix covers `ubuntu-22.04` (glibc) only. For musl: pass `--linux-container-image ghcr.io/rake-compiler/rake-compiler-dock-image:1.12.0-mri-x86_64-linux-musl` or add a matrix row manually.

--- a/cibuildgem.gemspec
+++ b/cibuildgem.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("prism")
   spec.add_dependency("rake-compiler")
+  spec.add_dependency("rake-compiler-dock", "~> 1.12")
   spec.add_dependency("thor")
 end

--- a/lib/cibuildgem.rb
+++ b/lib/cibuildgem.rb
@@ -4,7 +4,8 @@ require_relative "cibuildgem/version"
 require_relative "cibuildgem/errors"
 
 module Cibuildgem
-  autoload :CLI,              "cibuildgem/cli"
-  autoload :CompilationTasks, "cibuildgem/compilation_tasks"
-  autoload :RubySeries,       "cibuildgem/ruby_series"
+  autoload :CLI,               "cibuildgem/cli"
+  autoload :CompilationTasks,  "cibuildgem/compilation_tasks"
+  autoload :ContainerPackager, "cibuildgem/container_packager"
+  autoload :RubySeries,        "cibuildgem/ruby_series"
 end

--- a/lib/cibuildgem/cli.rb
+++ b/lib/cibuildgem/cli.rb
@@ -51,6 +51,68 @@ module Cibuildgem
       run_rake_tasks!("cibuildgem:setup", :cross, :native, :gem)
     end
 
+    desc "container_package", "Compile and package a Linux gem in a container."
+    long_desc <<~MSG
+      Build the gem inside a rake-compiler-dock Linux container.
+
+      Useful for testing the Linux build locally before pushing to CI. Works with Docker or Podman.
+    MSG
+    method_option "working-directory", type: "string", required: false, desc: "If your gem lives outside of the current directory, specify where."
+    method_option "gemspec", type: "string", required: false, desc: "The gemspec to use. Defaults to the gemspec from the selected working directory."
+    method_option "container-image", type: "string", required: false, desc: "Override the Linux container image used for packaging."
+    def container_package
+      working_directory = options["working-directory"] || Dir.pwd
+      packager = ContainerPackager.new(
+        working_directory: working_directory,
+        gemspec: options["gemspec"],
+        container_image: options["container-image"],
+      )
+
+      packager.package
+    rescue GemspecError, ContainerError => e
+      report_error(e.message)
+    end
+
+    desc "container_exec", "Run a command in a Linux container."
+    long_desc <<~MSG
+      Execute a shell command inside rake-compiler-dock.
+
+      Used by the GitHub action for the cross-test and install steps, and also available
+      for custom workflows.
+
+      The command can be passed via --command or the CIBUILDGEM_CONTAINER_COMMAND environment
+      variable (one of the two is required).
+    MSG
+    method_option "working-directory", type: "string", required: false, desc: "If your gem lives outside of the current directory, specify where."
+    method_option "gemspec", type: "string", required: false, desc: "The gemspec to use. Defaults to the gemspec from the selected working directory."
+    method_option "container-image", type: "string", required: false, desc: "Override the Linux container image used for packaging."
+    method_option "command", type: "string", required: false, desc: "The shell command to execute inside the container. Falls back to CIBUILDGEM_CONTAINER_COMMAND."
+    method_option "bundle-install", type: "boolean", required: false, default: false, desc: "Install bundle dependencies before executing the command."
+    def container_exec
+      working_directory = options["working-directory"] || Dir.pwd
+      command = options["command"] || ENV["CIBUILDGEM_CONTAINER_COMMAND"]
+
+      if command.nil? || command.strip.empty?
+        report_error(<<~MSG)
+          No container command was provided.
+          Pass one with --command "..." or set the CIBUILDGEM_CONTAINER_COMMAND environment variable.
+        MSG
+      end
+
+      packager = ContainerPackager.new(
+        working_directory: working_directory,
+        gemspec: options["gemspec"],
+        container_image: options["container-image"],
+      )
+
+      packager.run(
+        command: command,
+        prepare_bundle: options["bundle-install"],
+      )
+    rescue GemspecError, ContainerError => e
+      report_error(e.message)
+    end
+
     desc "test", "Run the test suites of the target gem"
     long_desc <<~EOM
       cibuildgem will run the test suite of the gem. It either expects a `spec` or `test` task defined.
@@ -95,6 +157,7 @@ module Cibuildgem
     MSG
     method_option "working-directory", type: "string", required: false, desc: "If your gem lives outside of the repository root, specify where."
     method_option "test-command", type: "string", required: false, desc: "The test command to run. Defaults to running `bundle exec rake test` and `bundle exec rake spec`."
+    method_option "linux-container-image", type: "string", required: false, desc: "Override the rake-compiler-dock image used for the Linux containerized steps."
     def ci_template
       ruby_requirements = compilation_task.gemspec.required_ruby_version
       # os = ["macos-latest", "macos-15-intel", "ubuntu-latest", "windows-latest"]
@@ -160,7 +223,14 @@ module Cibuildgem
     def compilation_task
       @compilation_task ||= CompilationTasks.new(false)
     rescue GemspecError => e
-      print(e.message)
+      report_error(e.message)
+    end
+
+    # Errors go to stderr (separable from real output in CI logs)
+    # and always end with a newline.
+    def report_error(message)
+      message = "#{message}\n" unless message.end_with?("\n")
+      $stderr.write(message)
 
       Kernel.exit(false)
     end

--- a/lib/cibuildgem/container_packager.rb
+++ b/lib/cibuildgem/container_packager.rb
@@ -177,7 +177,10 @@ module Cibuildgem
     end
 
     def load_source_gemspec
-      gemspec = Gem::Specification.load(File.join(source_path, "cibuildgem.gemspec"))
+      # gemspec uses Dir[...] which evaluates against pwd, hence the chdir
+      gemspec = Dir.chdir(source_path) do
+        Gem::Specification.load(File.join(source_path, "cibuildgem.gemspec"))
+      end
       raise ContainerError, "Unable to load cibuildgem.gemspec from #{source_path}." unless gemspec
 
       gemspec

--- a/lib/cibuildgem/container_packager.rb
+++ b/lib/cibuildgem/container_packager.rb
@@ -60,7 +60,8 @@ module Cibuildgem
       docker_options = ["--rm", "-i"]
       docker_options << "-t" if $stdin.tty?
       if host_gem_path
-        docker_options.push("-v", "#{File.dirname(host_gem_path)}:#{CONTAINER_SOURCE_PATH}:ro")
+        # `:z` is needed for SELinux/podman; ignored elsewhere
+        docker_options.push("-v", "#{File.dirname(host_gem_path)}:#{CONTAINER_SOURCE_PATH}:ro,z")
       end
       options[:options] = docker_options
 

--- a/lib/cibuildgem/container_packager.rb
+++ b/lib/cibuildgem/container_packager.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "pathname"
+require "shellwords"
+require "tmpdir"
+require "rake_compiler_dock"
+require "rubygems/user_interaction"
+
+module Cibuildgem
+  class ContainerPackager
+    CONTAINER_SOURCE_PATH = "/opt/cibuildgem-source"
+    HOST_BUILD_CACHE_DIRNAME = "cibuildgem-host-build-cache"
+
+    def initialize(working_directory: Dir.pwd, gemspec: nil, container_image: nil, version: nil)
+      @working_directory = File.expand_path(working_directory)
+      @gemspec_path = resolve_gemspec_path(gemspec)
+      @container_image = normalize_string(container_image || ENV["CIBUILDGEM_CONTAINER_IMAGE"])
+      @version = normalize_string(version || ENV["CIBUILDGEM_VERSION"])
+      @source_path = resolve_source_path
+      @compilation_task = with_working_directory do
+        CompilationTasks.new(false, @gemspec_path)
+      end
+    end
+
+    def package
+      run(command: package_command, prepare_bundle: true)
+    end
+
+    def run(command:, prepare_bundle: false)
+      raise ContainerError, "Container execution is only supported for Linux targets." unless linux_target?
+      raise ContainerError, "No container command was provided." if normalize_string(command).nil?
+
+      with_host_built_cibuildgem_gem do |host_gem_path|
+        RakeCompilerDock.sh(
+          container_command(command, prepare_bundle: prepare_bundle, host_gem_path: host_gem_path),
+          rake_compiler_dock_options(host_gem_path),
+        )
+      end
+    end
+
+    private
+
+    attr_reader :working_directory, :gemspec_path, :container_image, :version, :source_path, :compilation_task
+
+    def linux_target?
+      Gem::Platform.new(compilation_task.normalized_platform).os == "linux"
+    end
+
+    def rake_compiler_dock_options(host_gem_path)
+      options = {
+        platform: compilation_task.normalized_platform,
+        ruby: container_ruby_version,
+        mountdir: working_directory,
+        workdir: working_directory,
+      }
+      options[:image] = container_image if container_image
+
+      docker_options = ["--rm", "-i"]
+      docker_options << "-t" if $stdin.tty?
+      if host_gem_path
+        docker_options.push("-v", "#{File.dirname(host_gem_path)}:#{CONTAINER_SOURCE_PATH}:ro")
+      end
+      options[:options] = docker_options
+
+      options
+    end
+
+    def container_command(command, prepare_bundle:, host_gem_path:)
+      commands = [
+        "set -euo pipefail",
+        install_cibuildgem_command(host_gem_path),
+      ]
+      commands << bundle_install_command if prepare_bundle
+      commands << command
+
+      commands.join("\n")
+    end
+
+    # `bundle check` is unreliable here (lockfile rarely lists the runner's platform), so install unconditionally.
+    def bundle_install_command
+      <<~SH.strip
+        if [ -f Gemfile ]; then
+          export BUNDLE_PATH="$HOME/.cibuildgem-bundle"
+          bundle install --jobs=4 --retry=3
+        fi
+      SH
+    end
+
+    def install_cibuildgem_command(host_gem_path)
+      if version
+        "gem install --no-document cibuildgem -v #{version.shellescape}"
+      elsif host_gem_path
+        gem_in_container = "#{CONTAINER_SOURCE_PATH}/#{File.basename(host_gem_path)}"
+        "gem install --no-document #{gem_in_container.shellescape}"
+      else
+        raise ContainerError, <<~MSG
+          Can't figure out which cibuildgem to install in the container.
+          Set CIBUILDGEM_SOURCE_PATH to a checkout, or pass --version / CIBUILDGEM_VERSION.
+        MSG
+      end
+    end
+
+    def package_command
+      [
+        "export RUBY_CC_VERSION=#{RakeCompilerDock.ruby_cc_version(compilation_task.gemspec.required_ruby_version).shellescape}",
+        "cibuildgem package#{package_options}",
+      ].join("\n")
+    end
+
+    def package_options
+      return "" unless gemspec_path
+
+      relative_gemspec = Pathname.new(gemspec_path).relative_path_from(Pathname.new(working_directory)).to_s
+      " --gemspec #{relative_gemspec.shellescape}"
+    end
+
+    def container_ruby_version
+      RakeCompilerDock.ruby_cc_version(compilation_task.gemspec.required_ruby_version).split(":").first
+    end
+
+    def resolve_gemspec_path(gemspec)
+      return unless gemspec
+
+      File.expand_path(gemspec, working_directory)
+    end
+
+    def resolve_source_path
+      candidates = [
+        ENV["CIBUILDGEM_SOURCE_PATH"],
+        Gem.loaded_specs["cibuildgem"]&.full_gem_path,
+        File.expand_path("../..", __dir__),
+      ]
+
+      candidates.each do |candidate|
+        path = normalize_string(candidate)
+        next unless path
+
+        expanded = File.expand_path(path)
+        return expanded if File.file?(File.join(expanded, "cibuildgem.gemspec"))
+      end
+
+      nil
+    end
+
+    def normalize_string(value)
+      return if value.nil?
+
+      normalized = value.strip
+      normalized.empty? ? nil : normalized
+    end
+
+    def with_working_directory(&block)
+      Dir.chdir(working_directory, &block)
+    end
+
+    def with_host_built_cibuildgem_gem
+      return yield(nil) if version || source_path.nil?
+
+      gem_path = cached_or_built_gem_path
+      yield(gem_path)
+    end
+
+    def cached_or_built_gem_path
+      gemspec = load_source_gemspec
+      cache_dir = File.join(Dir.tmpdir, HOST_BUILD_CACHE_DIRNAME)
+      FileUtils.mkdir_p(cache_dir)
+
+      filename = "cibuildgem-#{gemspec.version}-#{source_fingerprint(gemspec)}.gem"
+      cached_path = File.join(cache_dir, filename)
+      return cached_path if File.file?(cached_path)
+
+      build_cibuildgem_gem(gemspec, cached_path)
+      cached_path
+    end
+
+    def load_source_gemspec
+      gemspec = Gem::Specification.load(File.join(source_path, "cibuildgem.gemspec"))
+      raise ContainerError, "Unable to load cibuildgem.gemspec from #{source_path}." unless gemspec
+
+      gemspec
+    end
+
+    def source_fingerprint(gemspec)
+      digest = Digest::SHA256.new
+      digest.update(File.binread(File.join(source_path, "cibuildgem.gemspec")))
+
+      gemspec.files.sort.each do |relative|
+        absolute = File.join(source_path, relative)
+        next unless File.file?(absolute)
+
+        digest.update(relative)
+        digest.update("\0")
+        digest.update(File.binread(absolute))
+      end
+
+      digest.hexdigest[0, 16]
+    end
+
+    def build_cibuildgem_gem(gemspec, destination_path)
+      Dir.mktmpdir("cibuildgem-host-build-") do |tmp|
+        built_gem_filename = Dir.chdir(source_path) do
+          Gem::DefaultUserInteraction.use_ui(Gem::SilentUI.new) do
+            Gem::Package.build(gemspec)
+          end
+        end
+
+        built_path = File.join(source_path, built_gem_filename)
+        scratch_path = File.join(tmp, built_gem_filename)
+        FileUtils.mv(built_path, scratch_path)
+        FileUtils.mv(scratch_path, destination_path)
+      end
+    end
+  end
+end

--- a/lib/cibuildgem/errors.rb
+++ b/lib/cibuildgem/errors.rb
@@ -2,4 +2,5 @@
 
 module Cibuildgem
   GemspecError = Class.new(StandardError)
+  ContainerError = Class.new(StandardError)
 end

--- a/lib/cibuildgem/templates/github/workflows/cibuildgem.yaml.tt
+++ b/lib/cibuildgem/templates/github/workflows/cibuildgem.yaml.tt
@@ -89,6 +89,9 @@ jobs:
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:
           step: "install"
+          <%- if options['working-directory'] -%>
+          working-directory: "<%= options['working-directory'] %>"
+          <%- end -%>
           <%- if options['linux-container-image'] -%>
           linux-container-image: "<%= options['linux-container-image'] %>"
           <%- end -%>

--- a/lib/cibuildgem/templates/github/workflows/cibuildgem.yaml.tt
+++ b/lib/cibuildgem/templates/github/workflows/cibuildgem.yaml.tt
@@ -35,6 +35,9 @@ jobs:
           <%- if options['working-directory'] -%>
           working-directory: "<%= options['working-directory'] %>"
           <%- end -%>
+          <%- if options['linux-container-image'] -%>
+          linux-container-image: "<%= options['linux-container-image'] %>"
+          <%- end -%>
   test:
     timeout-minutes: 20
     name: "Run the test suite"
@@ -66,6 +69,9 @@ jobs:
           <%- if options['test-command'] -%>
           test-command: "<%= options['test-command'] %>"
           <%- end -%>
+          <%- if options['linux-container-image'] -%>
+          linux-container-image: "<%= options['linux-container-image'] %>"
+          <%- end -%>
   install:
     timeout-minutes: 5
     name: "Verify the gem can be installed"
@@ -83,6 +89,9 @@ jobs:
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:
           step: "install"
+          <%- if options['linux-container-image'] -%>
+          linux-container-image: "<%= options['linux-container-image'] %>"
+          <%- end -%>
   release:
     environment: release
     permissions:

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -30,7 +30,7 @@ module Cibuildgem
       install_step_run = step("Install cibuildgem").fetch("run")
 
       assert_includes(install_step_run, "inputs.version != null, format(")
-      assert_includes(install_step_run, "github.repository == 'Shopify/cibuildgem', 'rake install'")
+      assert_includes(install_step_run, "endsWith(github.repository, '/cibuildgem'), 'rake install'")
       assert_includes(install_step_run, "'gem install cibuildgem'")
     end
 

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -61,6 +61,11 @@ module Cibuildgem
           env.fetch("CIBUILDGEM_VERSION"),
           "#{name}: version must be plumbed through",
         )
+        assert_equal(
+          "${{ endsWith(github.repository, '/cibuildgem') && github.workspace || '' }}",
+          env.fetch("CIBUILDGEM_SOURCE_PATH"),
+          "#{name}: source path must be set so installed-gem CI can rebuild from checkout",
+        )
       end
     end
 

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+module Cibuildgem
+  class ActionTest < Minitest::Test
+    ACTION_PATH = File.expand_path("../.github/actions/cibuildgem/action.yml", __dir__)
+
+    def test_linux_follow_up_steps_run_in_containers_by_default
+      assert_equal(
+        "${{ inputs.step == 'test_cross' && runner.os == 'Linux' }}",
+        step("Execute cross tests in Linux container").fetch("if"),
+      )
+      assert_equal(
+        "${{ inputs.step == 'install' && runner.os == 'Linux' }}",
+        step("Install gems in Linux container").fetch("if"),
+      )
+      assert_equal(
+        "${{ inputs.step == 'test_cross' && runner.os != 'Linux' }}",
+        step("Copy staging binary to the libdir").fetch("if"),
+      )
+      assert_equal(
+        "${{ inputs.step == 'install' && runner.os != 'Linux' }}",
+        step("Install gems").fetch("if"),
+      )
+    end
+
+    def test_action_install_step_branches_on_version_and_repository
+      install_step_run = step("Install cibuildgem").fetch("run")
+
+      assert_includes(install_step_run, "inputs.version != null, format(")
+      assert_includes(install_step_run, "github.repository == 'Shopify/cibuildgem', 'rake install'")
+      assert_includes(install_step_run, "'gem install cibuildgem'")
+    end
+
+    def test_linux_container_image_input_is_declared
+      input = action.fetch("inputs").fetch("linux-container-image")
+
+      refute(input.fetch("required"))
+      assert_includes(input.fetch("description"), "rake-compiler-dock")
+    end
+
+    def test_every_linux_container_step_passes_the_required_env_vars
+      linux_steps = [
+        "Package in Linux container",
+        "Execute cross tests in Linux container",
+        "Install gems in Linux container",
+      ]
+
+      linux_steps.each do |name|
+        env = step(name).fetch("env")
+
+        assert_equal(
+          "${{ inputs.linux-container-image }}",
+          env.fetch("CIBUILDGEM_CONTAINER_IMAGE"),
+          "#{name}: container image must be plumbed through",
+        )
+        assert_equal(
+          "${{ inputs.version }}",
+          env.fetch("CIBUILDGEM_VERSION"),
+          "#{name}: version must be plumbed through",
+        )
+      end
+    end
+
+    def test_download_artifact_steps_extract_into_the_working_directory
+      ["Download compiled binaries", "Download tarball for platform"].each do |name|
+        with = step(name).fetch("with")
+
+        assert_equal(
+          "${{ inputs.working-directory }}",
+          with.fetch("path"),
+          "#{name} must extract artifacts under the gem's working-directory",
+        )
+      end
+    end
+
+    def test_install_gems_step_runs_in_the_working_directory
+      assert_equal("${{ inputs.working-directory }}", step("Install gems").fetch("working-directory"))
+    end
+
+    def test_execute_the_tests_skips_the_linux_test_cross_path
+      assert_includes(
+        step("Execute the tests").fetch("if"),
+        "!(inputs.step == 'test_cross' && runner.os == 'Linux')",
+      )
+    end
+
+    private
+
+    def action
+      @action ||= YAML.safe_load_file(ACTION_PATH)
+    end
+
+    def step(name)
+      action.fetch("runs").fetch("steps").find do |step_definition|
+        step_definition["name"] == name
+      end || flunk("Unable to find action step: #{name}")
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -232,30 +232,30 @@ module Cibuildgem
     end
 
     def test_when_cli_runs_in_project_with_no_gemspec
-      out = nil
+      err = nil
 
       Dir.chdir("lib") do
-        out, _ = capture_subprocess_io do
+        _, err = capture_subprocess_io do
           raise_instead_of_exit do
             CLI.start(["print_ruby_cc_version"])
           end
         end
       end
 
-      assert_equal(<<~MSG, out)
+      assert_equal(<<~MSG, err)
         Couldn't find a gemspec in the current directory.
         Make sure to run any cibuildgem commands in the root of your gem folder.
       MSG
     end
 
     def test_when_cli_runs_in_project_with_no_native_extension
-      out, _ = capture_subprocess_io do
+      _, err = capture_subprocess_io do
         raise_instead_of_exit do
           CLI.start(["print_ruby_cc_version"])
         end
       end
 
-      assert_equal(<<~MSG, out)
+      assert_equal(<<~MSG, err)
         Your gem has no native extention defined in its gemspec.
         This tool can't be used on pure Ruby gems.
       MSG
@@ -301,6 +301,100 @@ module Cibuildgem
       end
 
       assert_predicate($CHILD_STATUS, :success?)
+    end
+
+    def test_container_package
+      received = {}
+      packager = Object.new
+      packager.define_singleton_method(:package) { received[:package_called] = true }
+
+      factory = ->(**kwargs) {
+        received[:kwargs] = kwargs
+        packager
+      }
+
+      ContainerPackager.stub(:new, factory) do
+        CLI.start(["container_package", "--working-directory", "foo/bar", "--container-image", "example/image"])
+      end
+
+      assert(received[:package_called])
+      assert_equal("foo/bar", received[:kwargs][:working_directory])
+      assert_nil(received[:kwargs][:gemspec])
+      assert_equal("example/image", received[:kwargs][:container_image])
+    end
+
+    def test_container_exec
+      received = {}
+      packager = Object.new
+      packager.define_singleton_method(:run) do |command:, prepare_bundle:|
+        received[:command] = command
+        received[:prepare_bundle] = prepare_bundle
+      end
+
+      factory = ->(**kwargs) {
+        received[:kwargs] = kwargs
+        packager
+      }
+
+      ContainerPackager.stub(:new, factory) do
+        CLI.start([
+          "container_exec",
+          "--working-directory",
+          "foo/bar",
+          "--container-image",
+          "example/image",
+          "--command",
+          "echo ok",
+          "--bundle-install",
+        ])
+      end
+
+      assert_equal("foo/bar", received[:kwargs][:working_directory])
+      assert_nil(received[:kwargs][:gemspec])
+      assert_equal("example/image", received[:kwargs][:container_image])
+      assert_equal("echo ok", received[:command])
+      assert(received[:prepare_bundle])
+    end
+
+    def test_container_exec_without_a_command_explains_the_two_input_paths
+      _, err = capture_subprocess_io do
+        raise_instead_of_exit do
+          CLI.start(["container_exec"])
+        end
+      end
+
+      assert_match(/No container command was provided/, err)
+      assert_match(/--command/, err)
+      assert_match(/CIBUILDGEM_CONTAINER_COMMAND/, err)
+    end
+
+    def test_container_exec_falls_back_to_env_var_for_the_command
+      ENV["CIBUILDGEM_CONTAINER_COMMAND"] = "echo from-env"
+      received = {}
+      packager = Object.new
+      packager.define_singleton_method(:run) do |command:, prepare_bundle:|
+        received[:command] = command
+        received[:prepare_bundle] = prepare_bundle
+      end
+
+      ContainerPackager.stub(:new, ->(**) { packager }) do
+        CLI.start(["container_exec"])
+      end
+
+      assert_equal("echo from-env", received[:command])
+      refute(received[:prepare_bundle])
+    ensure
+      ENV.delete("CIBUILDGEM_CONTAINER_COMMAND")
+    end
+
+    def test_errors_go_to_stderr_with_a_trailing_newline
+      _, err = capture_subprocess_io do
+        raise_instead_of_exit do
+          CLI.start(["container_exec"])
+        end
+      end
+
+      assert(err.end_with?("\n"), "expected stderr message to end with a newline, got #{err.inspect}")
     end
 
     def test_keep_the_extension_task_config_defined_by_the_gem

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -130,6 +130,22 @@ module Cibuildgem
       FileUtils.rm_rf("test/fixtures/dummy_gem/.github")
     end
 
+    def test_ci_template_propagates_linux_container_image
+      workflow_path = "test/fixtures/dummy_gem/.github/workflows/cibuildgem.yaml"
+      expected_workflow = File.read("test/fixtures/expected_github_workflow_container_image.yml")
+
+      Dir.chdir("test/fixtures/dummy_gem") do
+        capture_subprocess_io do
+          CLI.start(["ci_template", "--linux-container-image", "ghcr.io/example/custom-image:latest"])
+        end
+      end
+
+      assert(File.exist?(workflow_path))
+      assert_equal(expected_workflow, File.read(workflow_path))
+    ensure
+      FileUtils.rm_rf("test/fixtures/dummy_gem/.github")
+    end
+
     def test_release_succeeds
       FileUtils.touch("tmp/foo.gem")
       FileUtils.touch("tmp/bar.gem")

--- a/test/container_packager_test.rb
+++ b/test/container_packager_test.rb
@@ -41,7 +41,7 @@ module Cibuildgem
 
       mount_flag_index = options[:options].index("-v")
       assert(mount_flag_index, "expected a -v mount flag for the host-built gem")
-      assert_match(%r{:/opt/cibuildgem-source:ro\z}, options[:options][mount_flag_index + 1])
+      assert_match(%r{:/opt/cibuildgem-source:ro,z\z}, options[:options][mount_flag_index + 1])
 
       assert_includes(command, "gem install --no-document /opt/cibuildgem-source/cibuildgem-")
       refute_includes(command, "gem build cibuildgem.gemspec")

--- a/test/container_packager_test.rb
+++ b/test/container_packager_test.rb
@@ -84,6 +84,18 @@ module Cibuildgem
       end
     end
 
+    def test_load_source_gemspec_resolves_files_against_source_path_not_pwd
+      packager = ContainerPackager.new(working_directory: @fixture_path)
+
+      Dir.chdir(@fixture_path) do
+        gemspec = packager.send(:load_source_gemspec)
+
+        assert_equal("cibuildgem", gemspec.name)
+        assert_includes(gemspec.files, "lib/cibuildgem.rb")
+        refute(gemspec.files.any? { |f| f.start_with?("lib/date") }, "must not pick up files from the working_directory")
+      end
+    end
+
     def test_run_installs_the_requested_cibuildgem_version_and_skips_host_build
       ENV["CIBUILDGEM_VERSION"] = "9.9.9"
 

--- a/test/container_packager_test.rb
+++ b/test/container_packager_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake_compiler_dock"
+
+module Cibuildgem
+  class ContainerPackagerTest < Minitest::Test
+    def setup
+      super
+
+      @repo_root = File.expand_path("..", __dir__)
+      @fixture_path = File.join(@repo_root, "test/fixtures/date")
+      @original_source_path = ENV["CIBUILDGEM_SOURCE_PATH"]
+      @original_version = ENV["CIBUILDGEM_VERSION"]
+      ENV["CIBUILDGEM_SOURCE_PATH"] = @repo_root
+      ENV.delete("CIBUILDGEM_VERSION")
+    end
+
+    def teardown
+      ENV["CIBUILDGEM_SOURCE_PATH"] = @original_source_path
+      ENV["CIBUILDGEM_VERSION"] = @original_version
+
+      super
+    end
+
+    def test_package_runs_in_rake_compiler_dock_using_the_bind_mount
+      command, options = capture_rake_compiler_dock_invocation do
+        ContainerPackager.new(working_directory: @fixture_path, container_image: "custom:image").package
+      end
+
+      assert_equal("custom:image", options[:image])
+      assert_equal(@fixture_path, options[:mountdir])
+      assert_equal(@fixture_path, options[:workdir])
+      assert_equal("4.0.2", options[:ruby])
+
+      assert_includes(
+        options[:options],
+        "--rm",
+        "expected --rm flag so containers don't pile up between matrix jobs",
+      )
+
+      mount_flag_index = options[:options].index("-v")
+      assert(mount_flag_index, "expected a -v mount flag for the host-built gem")
+      assert_match(%r{:/opt/cibuildgem-source:ro\z}, options[:options][mount_flag_index + 1])
+
+      assert_includes(command, "gem install --no-document /opt/cibuildgem-source/cibuildgem-")
+      refute_includes(command, "gem build cibuildgem.gemspec")
+      refute_includes(command, "cp -R")
+      assert_includes(command, 'BUNDLE_PATH="$HOME/.cibuildgem-bundle"')
+      assert_includes(command, "bundle install --jobs=4 --retry=3")
+      assert_includes(command, "export RUBY_CC_VERSION=")
+      assert_includes(command, "cibuildgem package")
+    end
+
+    def test_package_omits_bundle_install_when_no_bundle_is_requested
+      command, _ = capture_rake_compiler_dock_invocation do
+        ContainerPackager.new(working_directory: @fixture_path).run(command: "echo hi")
+      end
+
+      refute_includes(command, "bundle install")
+      assert_includes(command, "echo hi")
+    end
+
+    def test_package_raises_for_non_linux_targets
+      packager = ContainerPackager.new(working_directory: @fixture_path)
+
+      packager.stub(:linux_target?, false) do
+        assert_raises(ContainerError) { packager.package }
+      end
+    end
+
+    def test_package_passes_through_musl_and_aarch64_platforms_to_rake_compiler_dock
+      [
+        "x86_64-linux-musl",
+        "aarch64-linux-musl",
+        "aarch64-linux-gnu",
+      ].each do |platform|
+        packager = ContainerPackager.new(working_directory: @fixture_path)
+        packager.send(:compilation_task).stub(:normalized_platform, platform) do
+          _, options = capture_rake_compiler_dock_invocation { packager.package }
+
+          assert_equal(platform, options[:platform], "expected #{platform} to be forwarded to rake-compiler-dock")
+        end
+      end
+    end
+
+    def test_run_installs_the_requested_cibuildgem_version_and_skips_host_build
+      ENV["CIBUILDGEM_VERSION"] = "9.9.9"
+
+      command, options = capture_rake_compiler_dock_invocation do
+        ContainerPackager.new(working_directory: @fixture_path, container_image: "custom:image")
+          .run(command: "echo ok")
+      end
+
+      assert_equal("custom:image", options[:image])
+      refute_includes(options[:options], "-v")
+      assert_includes(command, "gem install --no-document cibuildgem -v 9.9.9")
+      refute_includes(command, "gem build")
+      assert_includes(command, "echo ok")
+    end
+
+    private
+
+    def capture_rake_compiler_dock_invocation(&block)
+      command = nil
+      options = nil
+      capture = lambda do |cmd, args|
+        command = cmd
+        options = args
+      end
+
+      RakeCompilerDock.stub(:sh, capture, &block)
+
+      [command, options]
+    end
+  end
+end

--- a/test/fixtures/expected_github_workflow_container_image.yml
+++ b/test/fixtures/expected_github_workflow_container_image.yml
@@ -1,0 +1,92 @@
+name: "Package and release gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
+env:
+  CIBUILDGEM: 1
+jobs:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.1.7"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "compile"
+          linux-container-image: "ghcr.io/example/custom-image:latest"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+        rubies: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "test_${{ matrix.type }}"
+          linux-container-image: "ghcr.io/example/custom-image:latest"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "4.0.0"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "install"
+          linux-container-image: "ghcr.io/example/custom-image:latest"
+  release:
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "4.0.0"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "release"

--- a/test/fixtures/expected_github_workflow_test_and_workdir.yml
+++ b/test/fixtures/expected_github_workflow_test_and_workdir.yml
@@ -73,6 +73,7 @@ jobs:
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:
           step: "install"
+          working-directory: "foo/bar"
   release:
     environment: release
     permissions:

--- a/test/fixtures/expected_github_workflow_working_dir.yml
+++ b/test/fixtures/expected_github_workflow_working_dir.yml
@@ -72,6 +72,7 @@ jobs:
         uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
         with:
           step: "install"
+          working-directory: "test/fixtures/date"
   release:
     environment: release
     permissions:


### PR DESCRIPTION
Hello,

this is an attempt to tackle #37.
Gems built directly on `ubuntu-latest` end up linking against whatever glibc the runner ships with.
Building inside the rake-compiler-dock image pins glibc at 2.17 and removes that unwanted surprise.
There is now a `glibc_compat` job that fails the build if any `.so` references a newer symbol.


`Cibuildgem::ContainerPackager` wraps `RakeCompilerDock.sh`, builds the cibuildgem source on the host and then mounts it in the container.
The gem installation is in there and with the fingerprint, the gems should stay cached.
Furthermore the Action got a `linux-container-image` input for folks who want to override the rake-compiler-dock image.

Also I changed `Shopify/cibuildgem` to `endsWith(github.repository, '/cibuildgem')`  in order to have it it run on non-Shopify-forks so that the Action can be run on the respective fork.

**PS:** I'm looking for a new adventure in case anybody is looking to hire someone or in case someone would like to work with a Ruby/Rails/Crystal dev and I'm also open to move to a PO/PM role